### PR TITLE
feat: 카테고리 별 게시글 목록 조회 연동

### DIFF
--- a/Eiiii/src/App.js
+++ b/Eiiii/src/App.js
@@ -44,7 +44,7 @@ function App() {
         <Route path="/chat-list" element={<ChatList />}/>
         <Route path="/chat-request" element={<Request />}/>
         <Route path="/notice" element={<Notice />}/>
-        <Route path="/community" element={<Community />}/>
+        <Route path="/community/:category" element={<Community />}/>
         <Route path="/community-write" element={<Write />}/>
         <Route path="/community-detail" element={<Detail />}/>
         <Route path="/plan" element={<Plan />}/>

--- a/Eiiii/src/components/DetailCard.jsx
+++ b/Eiiii/src/components/DetailCard.jsx
@@ -1,26 +1,38 @@
-import React from "react";
+import React, { useMemo } from "react";
 import * as M from "../styles/components/styledDetailCard";
 
 const DetailCard = ({ user, onClose }) => {
+
+  // 프로필을 랜덤 이미지로 설정
+  const randomImg = useMemo(() => {
+    const imgList = [
+      "/images/profile1.svg",
+      "/images/profile2.svg"
+    ];
+    const randomIndex = Math.floor(Math.random()*imgList.length);
+    return imgList[randomIndex];
+  }, []);
+
   return (
     <M.DetailCard>
       <M.Text></M.Text>
       <M.ProfileImg>
+        <img src={randomImg} alt="profile" />
       </M.ProfileImg>
       <M.Profile1>
         <M.Nickname>{user.nickname}</M.Nickname>
-        <M.UserId>@{user.userId}</M.UserId>
+        <M.UserId>@{user.username}</M.UserId>
       </M.Profile1>
       <M.Profile2>
         <M.Detail>{user.major}</M.Detail>
-        <M.Detail>{user.grade}</M.Detail>
-        <M.Detail>{user.gender}</M.Detail>
-        <M.Detail>{user.mealType}</M.Detail>
-        <M.Detail>{user.type}</M.Detail>
-        <M.Detail>{user.goal}</M.Detail>
-        <M.Detail>{user.fav}</M.Detail>
-        <M.Detail>{user.msg}</M.Detail>
-        <M.Detail>{user.type2}</M.Detail>
+        <M.Detail>{user.year}</M.Detail>
+        <M.Detail>{user.preferred_gender}</M.Detail>
+        <M.Detail>{user.dining_style}</M.Detail>
+        <M.Detail>{user.eating_speed}</M.Detail>
+        <M.Detail>{user.meal_purpose}</M.Detail>
+        <M.Detail>{user.dessert}</M.Detail>
+        <M.Detail>{user.preferred_menu}</M.Detail>
+        <M.Detail>{user.dietary_restrictions}</M.Detail>
       </M.Profile2>
     </M.DetailCard>
   );

--- a/Eiiii/src/components/MatchCard.jsx
+++ b/Eiiii/src/components/MatchCard.jsx
@@ -1,10 +1,22 @@
-import React from "react";
+import React, { useMemo } from "react";
 import * as M from "../styles/pages/styledMatch"; 
 
 const MatchCard = ({ user, onClick }) => {
+
+  // 프로필을 랜덤 이미지로 설정
+  const randomImg = useMemo(() => {
+    const imgList = [
+      "/images/profile1.svg",
+      "/images/profile2.svg"
+    ];
+    const randomIndex = Math.floor(Math.random()*imgList.length);
+    return imgList[randomIndex];
+  }, []);
+
   return (
-    <M.Card onClick={onClick}>
+    <M.Card onClick={() => onClick(user, randomImg)}>
       <M.ProfileImg>
+        <img src={randomImg} alt="profile" />
       </M.ProfileImg>
       <M.InfoWrapper>
         <M.Profile1>

--- a/Eiiii/src/components/NavBar.jsx
+++ b/Eiiii/src/components/NavBar.jsx
@@ -23,7 +23,7 @@ const NavBar = () => {
                     alt="chat"
                 />  
             </N.Icon>
-            <N.Icon onClick={() => navigate("/community")}>
+            <N.Icon onClick={() => navigate("/community/mentoring")}>
                 <img
                     id="user-group"
                     src={`${process.env.PUBLIC_URL}/images/user-group.svg`}

--- a/Eiiii/src/pages/Community.jsx
+++ b/Eiiii/src/pages/Community.jsx
@@ -1,14 +1,18 @@
 import * as M from "../styles/pages/styledCommunity"
 import NavBar from "../components/NavBar"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useParams } from "react-router-dom"
+import { useState, useEffect, useMemo } from "react"
+import axios from "axios"
 import styled from "styled-components"
 import { PageContainer } from "../styles/common/styledConainer"
+import DetailCard from "../components/DetailCard"
+import { BackgroundOverlay } from "../styles/common/styledBackground"
 
 // Header Component
 const Header = () => {
-    const navigate = useNavigate()
-  
-    return (
+  const navigate = useNavigate()
+
+  return (
       <Wrapper>
           <Back onClick={() => navigate(-1)}>
               <img
@@ -73,155 +77,146 @@ const Header = () => {
       margin-left: 69px;
   `
 
-const Community = () => {
+// Community Page
+const Community = ({user, onClick}) => {
     const navigate = useNavigate()
+    const [posts, setPosts] = useState([]);
+    const { category } = useParams();
+    const accessToken = localStorage.getItem("accessToken")
+    const [selectedUser, setSelectedUser] = useState(null);
+    const [isDetailLoading, setIsDetailLoading] = useState(false);
+    const [selectedImg, setSelectedImg] = useState(null);
+
+    useEffect(() => {
+      const fetchPosts = async () => {
+          try {
+              const res = await axios.get(`http://localhost:8000/api/communities/${category}`, {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+              });
+              console.log("📦 게시글 응답:", res.data);
+              setPosts(res.data);
+          } catch (err) {
+              console.error("게시글 불러오기 실패", err);
+          }
+      };
+
+      if (category) {
+        fetchPosts();
+      }
+    }, [category]);
+    // 매칭 상세 카드 불러오기 
+    const handleCardClick = async (user, image) => {
+        try {
+        // debugging code
+        console.log("user:", user);
+        setIsDetailLoading(true);
+        const res = await axios.get(`/api/accounts/profile/${user.id}/`, {
+            headers: {
+            Authorization: `Bearer ${accessToken}`,
+            },
+        });
+        setSelectedUser(res.data)
+        setSelectedImg(image)
+        } catch(err) {
+        console.error("상세 카드 불러오기 실패", err);
+        } finally {
+        setIsDetailLoading(false);
+        }
+    };
+
+    // 프로필을 랜덤 이미지로 설정
+      const randomImg = useMemo(() => {
+        const imgList = [
+          "/images/profile1.svg",
+          "/images/profile2.svg"
+        ];
+        const randomIndex = Math.floor(Math.random()*imgList.length);
+        return imgList[randomIndex];
+      }, []);
+
+    // 모달 창 닫기
+    const handleCloseDetail = () => {
+        setSelectedUser(null);
+      };
 
     return (
         <PageContainer>
-        <Header />
-        <M.Wrapper>
-            <M.Item>
-                <M.Profile>
-                    <M.Pic>
-                        <img 
-                        src={`${process.env.PUBLIC_URL}/images/avatar.svg`}
-                        />
-                    </M.Pic>
-                    <M.Infos>
+            <Header />
+            {/* 게시글 목록 */}
+            <M.Wrapper>
+                {posts.length > 0 ? (
+                posts.map((post) => (
+                    <M.Post>
+                    <M.Item key={post.id}>
+                    <M.Profile>
+                        <M.Pic onClick={() => handleCardClick({id: post.user-1}, randomImg)}>
+                        <img src={randomImg} alt="profile" />
+                        </M.Pic>
+                        <M.Infos>
                         <M.Info1>
-                            <M.Name>밥먹는 하마</M.Name>
-                            <M.Time>방금</M.Time>
+                            <M.Name>{post.nickname || "익명"}</M.Name>
+                            <M.Time>{post.created_at || "방금"}</M.Time>
                         </M.Info1>
                         <M.Info2>
-                            성악과 22학번
-                            <img 
-                            src={`${process.env.PUBLIC_URL}/images/dote.svg`}
-                            />
-                            23살
-                    </M.Info2>
-                    </M.Infos>
-                </M.Profile>
-                <M.Content onClick={() => navigate("/community-detail")}>
-                    <M.Big>0993학번 있나요?</M.Big>
-                    가나다라마바사 아자차카 타파아 글을써보십다 <br></br>
-                    두줄까진 허용입니다. 더이상 보고싶으면 더보기를 클릭 ···
-                    <M.Etc>더보기</M.Etc>
-                </M.Content>
-                <M.Bottom>
-                <M.Like>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/heart.svg`} />
-                    5
-                </M.Like>
-                <M.Comment>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/comment.svg`} />
-                    5
-                </M.Comment>
-                <M.Scrap>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/scrap.svg`} />
-                    5
-                </M.Scrap>
-                <M.More>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/more.svg`} />
-                    
-                </M.More>
-                </M.Bottom>
-            </M.Item>
-            <M.Line></M.Line>
-            <M.Item>
-                <M.Profile>
-                    <M.Pic>
-                        <img 
-                        src={`${process.env.PUBLIC_URL}/images/avatar.svg`}
-                        />
-                    </M.Pic>
-                    <M.Infos>
-                        <M.Info1>
-                            <M.Name>밥먹는 하마</M.Name>
-                            <M.Time>방금</M.Time>
-                        </M.Info1>
-                        <M.Info2>
-                            성악과 22학번
-                            <img 
-                            src={`${process.env.PUBLIC_URL}/images/dote.svg`}
-                            />
-                            23살
-                    </M.Info2>
-                    </M.Infos>
-                </M.Profile>
-                <M.Content onClick={() => navigate("/community-detail")}>
-                    <M.Big>0993학번 있나요?</M.Big>
-                    가나다라마바사 아자차카 타파아 글을써보십다 <br></br>
-                    두줄까진 허용입니다. 더이상 보고싶으면 더보기를 클릭 ···
-                    <M.Etc>더보기</M.Etc>
-                </M.Content >
-                <M.Bottom>
-                <M.Like>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/heart.svg`} />
-                    5
-                </M.Like>
-                <M.Comment>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/comment.svg`} />
-                    5
-                </M.Comment>
-                <M.Scrap>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/scrap.svg`} />
-                    5
-                </M.Scrap>
-                <M.More>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/more.svg`} />
-                </M.More>
-                </M.Bottom>
-            </M.Item>
-            <M.Line></M.Line>
-            <M.Item>
-                <M.Profile>
-                    <M.Pic>
-                        <img 
-                        src={`${process.env.PUBLIC_URL}/images/avatar.svg`}
-                        />
-                    </M.Pic>
-                    <M.Infos>
-                        <M.Info1>
-                            <M.Name>밥먹는 하마</M.Name>
-                            <M.Time>방금</M.Time>
-                        </M.Info1>
-                        <M.Info2>
-                            성악과 22학번
-                            <img 
-                            src={`${process.env.PUBLIC_URL}/images/dote.svg`}
-                            />
-                            23살
-                    </M.Info2>
-                    </M.Infos>
-                </M.Profile>
-                <M.Content onClick={() => navigate("/community-detail")}>
-                    <M.Big>새로 생긴 훠궈집 같이 가실 분 4분 구해요!</M.Big>
-                    4명이서 같이 가면 개업 이벤트로 20퍼 할인 해준대요!! <br></br>그 달에 생일인 사람있는 테이블은 추가로 10퍼 할인 더 ···
-                    <M.Etc>더보기</M.Etc>
-                </M.Content>
-                <M.Bottom>
-                <M.Like>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/heart.svg`} />
-                    5
-                </M.Like>
-                <M.Comment>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/comment.svg`} />
-                    5
-                </M.Comment>
-                <M.Scrap>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/scrap.svg`} />
-                    5
-                </M.Scrap>
-                <M.More>
-                    <M.IconImg src={`${process.env.PUBLIC_URL}/images/more.svg`} />
-                    
-                </M.More>
-                </M.Bottom>
-            </M.Item>
-           <M.Line></M.Line>
-        </M.Wrapper>
-        <M.WriteBtn onClick={() => navigate("/community-write")}>글쓰기</M.WriteBtn>
+                            {post.major} {post.year}학번
+                        </M.Info2>
+                        </M.Infos>
+                    </M.Profile>
+
+                    <M.Content onClick={() => navigate(`/community-detail/${post.id}`)}>
+                        <M.Big>{post.title}</M.Big>
+                        <p>{post.content.slice(0, 50)}...</p>
+                        <M.Etc>더보기</M.Etc>
+                    </M.Content>
+
+                    <M.Bottom>
+                        <M.Like>
+                        <M.IconImg src={`${process.env.PUBLIC_URL}/images/heart.svg`} />
+                        {post.likes ?? 0}
+                        </M.Like>
+                        <M.Comment>
+                        <M.IconImg src={`${process.env.PUBLIC_URL}/images/comment.svg`} />
+                        {post.comments ?? 0}
+                        </M.Comment>
+                        <M.Scrap>
+                        <M.IconImg src={`${process.env.PUBLIC_URL}/images/scrap.svg`} />
+                        {post.scraps ?? 0}
+                        </M.Scrap>
+                        <M.More>
+                        <M.IconImg src={`${process.env.PUBLIC_URL}/images/more.svg`} />
+                        </M.More>
+                    </M.Bottom>
+                    </M.Item>
+                    </M.Post>
+                ))
+                ) : (
+                <M.EmptyText>등록된 글이 없습니다.</M.EmptyText>
+                )}
+            </M.Wrapper>
+
+      {/* 글쓰기 버튼 (카테고리 유지) */}
+        <M.WriteBtn onClick={() => navigate(`/community-write?category=${category}`)}>
+            글쓰기
+        </M.WriteBtn>        
         <NavBar></NavBar>
+
+        {/* 배경 흐리게 */}
+        {selectedUser && <BackgroundOverlay></BackgroundOverlay>}
+        {/* 프로필 클릭 시 상세 카드 창 */}
+        {selectedUser && !isDetailLoading && (
+            <DetailCard user={selectedUser} img={selectedImg}/>
+        )}
+
+        {selectedUser && (
+        <M.ButtonGroup>
+            <M.ApplyBtn onClick={handleCloseDetail}>대화 신청</M.ApplyBtn>
+            <M.ExtBtn onClick={handleCloseDetail}>나가기</M.ExtBtn>
+        </M.ButtonGroup>
+        )}
+
+        {isDetailLoading && <p>불러오는 중</p>}
         </PageContainer>
     )
 }

--- a/Eiiii/src/pages/Home.jsx
+++ b/Eiiii/src/pages/Home.jsx
@@ -79,7 +79,7 @@ const Home = () => {
                     </H.Text>
                 </H.IconDiv1>
                 <H.IconDiv2>
-                    <H.Icon2 onClick={() => navigate('/community')}>
+                    <H.Icon2 onClick={() => navigate('/community/mentoring')}>
                         <img
                             src={`${process.env.PUBLIC_URL}/images/icon2.svg`}
                             alt="logo"
@@ -92,7 +92,7 @@ const Home = () => {
                     </H.Text>
                 </H.IconDiv2>
                 <H.IconDiv3>
-                    <H.Icon3>
+                    <H.Icon3 onClick={() => navigate('/community/regular')}>
                         <img
                             src={`${process.env.PUBLIC_URL}/images/icon3.svg`}
                             alt="logo"
@@ -105,7 +105,7 @@ const Home = () => {
                     </H.Text>
                 </H.IconDiv3>
                 <H.IconDiv4>
-                    <H.Icon4>
+                    <H.Icon4 onClick={() => navigate('/community/classmate')}>
                         <img
                             src={`${process.env.PUBLIC_URL}/images/icon4.svg`}
                             alt="logo"

--- a/Eiiii/src/pages/Match.jsx
+++ b/Eiiii/src/pages/Match.jsx
@@ -12,9 +12,9 @@ import axios from "axios";
 
 const Match = ({ dataList }) => {
   const navigate = useNavigate();
-  const [matchList, setMatchList] = useState([]);
-  const [selectedUser, setSelectedUser] = useState(null);
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [matchList, setMatchList] = useState([]); // 매치 카드
+  const [selectedUser, setSelectedUser] = useState(null); // 유저
+  const [isDetailLoading, setIsDetailLoading] = useState(false); // 상세 카드 로딩
   const [selectedImg, setSelectedImg] = useState(null);
 
   const accessToken = localStorage.getItem("accessToken");
@@ -23,14 +23,20 @@ const Match = ({ dataList }) => {
   useEffect(() => {
     const fetchMatchList = async () => {
       try {
-        const res = await axios.get("api/accounts/match/", {
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
+        const profileRes = await axios.get("/api/accounts/profile/me/", {
+          headers: { Authorization: `Bearer ${accessToken}` },
         });
-        setMatchList(res.data);
-      } catch(err) {
-        console.error("매칭 리스트 불러오기 실패", err)
+  
+        const matchRes = await axios.get("api/accounts/match/", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+  
+        // 내 프로필을 matchList 제일 앞에 삽입
+        const myProfile = { ...profileRes.data, isMe: true }; // isMe 플래그 추가 (선택)
+        setMatchList([myProfile, ...matchRes.data]);
+      } catch (err) {
+        console.error("매칭 리스트 불러오기 실패", err);
+      
       }
     };
 
@@ -77,11 +83,11 @@ const Match = ({ dataList }) => {
         </M.CardWrapper>
         <NavBar></NavBar>
         <>
-      {/* 배경 흐림 처리 */}
+      {/* 배경 흐리게 */}
         {selectedUser && <BackgroundOverlay></BackgroundOverlay>}
 
         
-      {/* 상세 카드 */}
+      {/* 상세 프로필 카드 모달 창 */}
       {selectedUser && ! isDetailLoading && (
         <DetailCard user={selectedUser}  img={selectedImg}/>
       )} 

--- a/Eiiii/src/pages/Match.jsx
+++ b/Eiiii/src/pages/Match.jsx
@@ -15,6 +15,7 @@ const Match = ({ dataList }) => {
   const [matchList, setMatchList] = useState([]);
   const [selectedUser, setSelectedUser] = useState(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [selectedImg, setSelectedImg] = useState(null);
 
   const accessToken = localStorage.getItem("accessToken");
 
@@ -37,15 +38,18 @@ const Match = ({ dataList }) => {
   }, [accessToken]);
 
   // 매칭 상세 카드 불러오기 
-  const handleCardClick = async (user) => {
+  const handleCardClick = async (user, image) => {
     try {
+      // debugging code
+      console.log(user);
       setIsDetailLoading(true);
-      const res = await axios.get(`/api/accounts/profile/${user.pk}/`, {
+      const res = await axios.get(`/api/accounts/profile/${user.id}/`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
       });
       setSelectedUser(res.data)
+      setSelectedImg(image)
     } catch(err) {
       console.error("상세 카드 불러오기 실패", err);
     } finally {
@@ -68,7 +72,7 @@ const Match = ({ dataList }) => {
       />
         <M.CardWrapper>
           {matchList.map((user) => (
-            <MatchCard user={user} onClick={() => handleCardClick(user)} />
+            <MatchCard user={user} onClick={handleCardClick} />
           ))}
         </M.CardWrapper>
         <NavBar></NavBar>
@@ -79,7 +83,7 @@ const Match = ({ dataList }) => {
         
       {/* 상세 카드 */}
       {selectedUser && ! isDetailLoading && (
-        <DetailCard text="대화 신청을 해보세요!" user={selectedUser}  />
+        <DetailCard user={selectedUser}  img={selectedImg}/>
       )} 
 
       {isDetailLoading && <M.LoadingText>불러오는 중</M.LoadingText>}

--- a/Eiiii/src/pages/Match.jsx
+++ b/Eiiii/src/pages/Match.jsx
@@ -23,17 +23,23 @@ const Match = ({ dataList }) => {
   useEffect(() => {
     const fetchMatchList = async () => {
       try {
-        const profileRes = await axios.get("/api/accounts/profile/me/", {
+        const res = await axios.get("/api/accounts/match/", {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-  
-        const matchRes = await axios.get("api/accounts/match/", {
+
+        const myRes = await axios.get(`/api/accounts/profile/me`, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
-  
-        // 내 프로필을 matchList 제일 앞에 삽입
-        const myProfile = { ...profileRes.data, isMe: true }; // isMe 플래그 추가 (선택)
-        setMatchList([myProfile, ...matchRes.data]);
+
+        const myProfile = {...myRes.data, isMe: true}
+
+        const matchRes = await axios.get("/api/accounts/match/", {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        const matchList =[myProfile, ...matchRes.data].sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+        setMatchList(matchList);
       } catch (err) {
         console.error("매칭 리스트 불러오기 실패", err);
       

--- a/Eiiii/src/pages/Write.jsx
+++ b/Eiiii/src/pages/Write.jsx
@@ -1,110 +1,134 @@
-import * as W from "../styles/pages/styledWrite"
-import { PageContainer } from "../styles/common/styledConainer"
-import { useNavigate } from "react-router-dom"
+import * as W from "../styles/pages/styledWrite";
+import { PageContainer } from "../styles/common/styledConainer";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useState } from "react";
 import axios from "axios";
 
 const Write = () => {
-    const navigate = useNavigate()
-    const [category, setCategory] = useState("");
-    const [title, setTitle] = useState("");
-    const [content, setContent] = useState("");
-    const [photo, setPhoto] = useState(null);
+  const navigate = useNavigate();
 
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [photo, setPhoto] = useState(null);
+
+  const [searchParams] = useSearchParams();
+  const initialCategory = searchParams.get("category") || "";
+  const [category, setCategory] = useState("");
+
+  const accessToken = localStorage.getItem("accessToken");
+
+  // 카테고리 값 
+  const categoryLabel = {
+    mentoring: "선후배 밥약",
+    regular: "정기 밥약",
+    classmate: "같은 수업 밥약",
+  };
+
+  const handleSubmit = async () => {
     const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken) {
+      alert("로그인이 필요합니다.");
+      navigate("/login");
+      return;
+    }
+  
+    try {
+      if (!category) {
+        alert("카테고리를 선택해주세요.");
+        return;
+      }
+  
+      const apiUrl = "http://localhost:8000/api/communities/create/";
+  
+      const body = {
+        category,   // "mentoring", "regular", "classmate" 등
+        title,
+        content,
+        photo: null,
+      };
+  
+      const res = await axios.post(apiUrl, body, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+      });
+  
+      alert("게시글이 등록되었습니다.");
+      navigate(`/community/${category}`);
+    } catch (error) {
+      console.error("게시글 등록 실패:", error);
+      alert("게시글 등록 실패");
+    }
+  };
+  
 
-    const handleSubmit = async () => {
-        const accessToken = localStorage.getItem("accessToken");
-        if (!accessToken) {
-            alert("로그인이 필요합니다.");
-            navigate("/login");
-            return;
-        }
-    
-        try {
-            const body = {
-                category,
-                title,
-                content,
-                photo: null, // 우선 비워두거나 백엔드 요구 방식에 맞게 처리
-            };
-    
-            const res = await axios.post("/api/communities/create/", body, {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                    "Content-Type": "application/json",
-                },
-            });
-    
-            alert("게시글이 등록되었습니다.");
-            navigate("/community");
-        } catch (error) {
-            console.error("게시글 등록 실패:", error);
-            alert("게시글 등록 실패");
-        }
-    };
-    
+  return (
+    <PageContainer>
+      <W.Header>
+        <W.Cancle onClick={() => navigate(-1)}>
+          <img
+            id="cancle"
+            src={`${process.env.PUBLIC_URL}/images/cancle.svg`}
+            alt="cancle"
+          />
+        </W.Cancle>
+        <W.Name>글 쓰기</W.Name>
+        <W.Regist onClick={handleSubmit}>등록</W.Regist>
+      </W.Header>
 
-    return (
-        <PageContainer>
-        <W.Header>
-            <W.Cancle onClick={() => navigate(-1)}>
-                <img 
-                    id="cancle"
-                    src={`${process.env.PUBLIC_URL}/images/cancle.svg`}
-                    alt="cancle"
-                />
-            </W.Cancle>
-            <W.Name>글 쓰기</W.Name>
-            <W.Regist onClick={handleSubmit}>등록</W.Regist>
-        </W.Header>
-            <W.Box>
-            <W.Category>
-                <p>
-                    {category
-                    ? category === "regular"
-                        ? "일반"
-                        : category === "notice"
-                        ? "공지"
-                        : "자유"
-                    : "카테고리를 선택해주세요."}
-                </p>
-                <select onChange={(e) => setCategory(e.target.value)} value={category}>
-                    <option value="regular">일반</option>
-                    <option value="notice">공지</option>
-                    <option value="free">자유</option>
-                </select>
-            </W.Category>
+      <W.Box>
+        {/* 카테고리 선택 */}
+        <W.Category>
+          <W.SelectedCategory onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
+            {category ? categoryLabel[category] : "카테고리를 선택해 주세요"}
+            <img src="/images/open.svg" alt="open" />
+          </W.SelectedCategory>
 
-                <W.Line></W.Line>
-                <W.Title 
-                    placeholder="제목을 입력해주세요."
-                    value={title}    
-                    onChange={(e) => setTitle(e.target.value)}
-                >
-                </W.Title>
-                <W.Line></W.Line>
-                <W.Content 
-                    placeholder="내용을 입력해주세요."
-                    value={content}
-                    onChange={(e) => setContent(e.target.value)}
-                >
-                </W.Content>
-            </W.Box>
-            <W.Cam>
-                <label htmlFor="fileInput">
-                <img src={`${process.env.PUBLIC_URL}/images/cam.svg`} alt="upload" />
-                </label>
-                <input
-                    id="fileInput"
-                    type="file"
-                    accept="image/*"
-                    style={{ display: "none" }}
-                    onChange={(e) => setPhoto(e.target.files[0])}
-                />
-            </W.Cam>
-        </PageContainer>
-    )
-}
+          {isDropdownOpen && (
+            <W.Dropdown>
+              <li onClick={() => { setCategory("mentoring"); setIsDropdownOpen(false); }}>선후배 밥약</li>
+              <li onClick={() => { setCategory("regular"); setIsDropdownOpen(false); }}>정기 밥약</li>
+              <li onClick={() => { setCategory("classmate"); setIsDropdownOpen(false); }}>같은 수업 밥약</li>
+            </W.Dropdown>
+          )}
+        </W.Category>
+
+        <W.Line />
+
+        {/* 제목 */}
+        <W.Title
+          placeholder="제목을 입력해주세요."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <W.Line />
+
+        {/* 내용 */}
+        <W.Content
+          placeholder="내용을 입력해주세요."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+      </W.Box>
+
+      {/* 이미지 첨부 */}
+      <W.Cam>
+        <label htmlFor="fileInput">
+          <img src={`${process.env.PUBLIC_URL}/images/cam.svg`} alt="upload" />
+        </label>
+        <input
+          id="fileInput"
+          type="file"
+          accept="image/*"
+          style={{ display: "none" }}
+          onChange={(e) => setPhoto(e.target.files[0])}
+        />
+      </W.Cam>
+    </PageContainer>
+  );
+};
 
 export default Write;

--- a/Eiiii/src/styles/pages/styledCommunity.jsx
+++ b/Eiiii/src/styles/pages/styledCommunity.jsx
@@ -21,14 +21,24 @@ export const Container = styled.div`
 export const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
-    align-self: flex-start;
     gap: 15px;
+    height: 680px;
+    width: 100%;
+    overflow-y: auto;
+    &::-webkit-scrollbar {
+    display: none;
+}
+
 `
 export const Item  = styled.div`
     display: flex;
     flex-direction: column;
     margin-left: 18px;
     cursor: pointer;
+    margin-bottom: 10px;
+`
+export const Post = styled.div`
+    border-bottom: 1px solid #EFBE78;
 `
 export const Profile = styled.div`
     display: flex;
@@ -44,6 +54,10 @@ export const Pic = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    img {
+        width: 24px;
+        height: 24px;
+    }
 `
 export const Infos = styled.div`
     display: flex;
@@ -189,4 +203,62 @@ export const Line = styled.div`
     width: 440px;
     height: 1px;
     background: #EFBE78;
+`
+
+
+export const EmptyText = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: fit-content;
+    text-align: center;
+    margin: 0 auto;
+`
+export const ButtonGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    z-index: 11;
+`;
+
+export const ApplyBtn = styled.button`
+    width: 305px;
+    height: 46px;
+    flex-shrink: 0;
+    border-radius: 11px;
+    background: #F8B621;
+    color: #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    cursor: pointer;
+    border: none;
+     &:active {
+        background: #F99505;
+    };
+`
+
+export const ExtBtn = styled.button`
+    width: 305px;
+    height: 46px;
+    flex-shrink: 0;
+    border-radius: 11px;
+    background: #F8B621;
+    color: #ffffff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    cursor: pointer;
+    border: none;
+     &:active {
+        background: #F99505;
+    };
 `

--- a/Eiiii/src/styles/pages/styledMatch.jsx
+++ b/Eiiii/src/styles/pages/styledMatch.jsx
@@ -55,7 +55,10 @@ export const CardWrapper = styled.div`
     display: grid;
     grid-template-columns: repeat(2, 1fr); // 두 열
     gap: 15px;
-    margin-bottom: 19px;
+    height: 750px;
+        overflow-y: auto;
+    &::-webkit-scrollbar {
+    display: none;
 `
 export const Card = styled.div`
     width: 180.686px;
@@ -152,7 +155,7 @@ export const ButtonGroup = styled.div`
     flex-direction: column;
     gap: 12px;
     z-index: 11;
-    margin-top: -100px;
+    margin-bottom: 100px;
 `;
 
 export const ApplyBtn = styled.button`

--- a/Eiiii/src/styles/pages/styledMatch.jsx
+++ b/Eiiii/src/styles/pages/styledMatch.jsx
@@ -163,7 +163,7 @@ export const ButtonGroup = styled.div`
     flex-direction: column;
     gap: 12px;
     z-index: 11;
-    margin-top: -105px;
+    margin-top: 100px;
 `;
 
 export const ApplyBtn = styled.button`

--- a/Eiiii/src/styles/pages/styledMatch.jsx
+++ b/Eiiii/src/styles/pages/styledMatch.jsx
@@ -147,23 +147,12 @@ export const Detail = styled.div`
     justify-content: center;
 `
 
-export const BackgroundOverlay = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: #888376;
-    opacity: 0.7;
-    z-index: 10;
-`;
-
 export const ButtonGroup = styled.div`
     display: flex;
     flex-direction: column;
     gap: 12px;
     z-index: 11;
-    margin-top: 100px;
+    margin-top: -100px;
 `;
 
 export const ApplyBtn = styled.button`

--- a/Eiiii/src/styles/pages/styledWrite.jsx
+++ b/Eiiii/src/styles/pages/styledWrite.jsx
@@ -73,9 +73,44 @@ export const Category = styled.div`
     font-family: "Spoqa Han Sans Neo";
     font-size: 20px;
     font-style: normal;
-    font-weight: 500;
     line-height: normal;
-    gap: 147px;
+    position: relative;
+`
+
+export const SelectedCategory = styled.div`
+display: flex;
+align-items: center;
+position: relative;
+justify-content: space-between;
+width: 100%;
+padding: 12px 0px;
+    img {
+    width: 18px;
+    height: 18px;
+    object-fit: contain;
+    flex-shrink: 0;
+    margin-right: 20px;
+    }
+`
+
+export const Dropdown = styled.div`
+display: flex;
+flex-direction: column;
+cursor: pointer;
+position: absolute;
+align-items: flex-end;
+margin-top: 40px;
+width: 100%;
+list-style: none;
+  li {
+    padding: 10px 16px;
+    font-size: 16px;
+    cursor: pointer;
+    background: #fff;
+    &:hover {
+      background: #fff7e0;
+    }
+  }
 `
 
 export const Title = styled.input`


### PR DESCRIPTION
## 📌 작업 내용
- 카테고리 별 게시글 목록 조회 
- 프로필 카드 목록 조회

## 🔍 작업 상세
- 카테고리 별(선후배 밥약, 정기 밥약, 같은 수업 밥약) 게시글 목록 조회 연동
- 프로필 입력 시 프로필 상세 카드 모달 창
- 프로필 사진 랜덤 이미지 띄우기
- 프로필 생성 순으로 프로필 목록 조회

## 🧪 테스트 결과
<img width="469" height="971" alt="image" src="https://github.com/user-attachments/assets/a5eff2ae-09cf-4b90-afe0-71f4b1c6af6d" />
<img width="474" height="980" alt="image" src="https://github.com/user-attachments/assets/72187ae4-ad6c-479f-9394-23803752ba79" />


## 🗨 기타 참고 사항
- 글 목록에서 최상단 프로필 클릭 시 401 에러
